### PR TITLE
[#10139] improvement (trino-connector): Include all Trino connector versions in distribution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -909,6 +909,10 @@ tasks {
 
   val assembleDistribution by registering(Tar::class) {
     dependsOn(
+      ":trino-connector:trino-connector-435-439:assembleTrinoConnector",
+      ":trino-connector:trino-connector-440-445:assembleTrinoConnector",
+      ":trino-connector:trino-connector-446-451:assembleTrinoConnector",
+      ":trino-connector:trino-connector-452-468:assembleTrinoConnector",
       ":trino-connector:trino-connector-469-472:assembleTrinoConnector",
       "assembleIcebergRESTServer",
       "assembleLanceRESTServer"

--- a/dev/release/release-build.sh
+++ b/dev/release/release-build.sh
@@ -254,12 +254,15 @@ if [[ "$1" == "package" ]]; then
       --detach-sig gravitino-lance-rest-server-$GRAVITINO_VERSION-bin.tar.gz
     shasum -a 512 gravitino-lance-rest-server-$GRAVITINO_VERSION-bin.tar.gz > gravitino-lance-rest-server-$GRAVITINO_VERSION-bin.tar.gz.sha512
 
-    echo "Copying and signing Gravitino Trino connector binary distribution"
-    cp gravitino-$GRAVITINO_VERSION-bin/distribution/gravitino-trino-connector-$GRAVITINO_VERSION.tar.gz .
-    echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
-      --output gravitino-trino-connector-$GRAVITINO_VERSION.tar.gz.asc \
-      --detach-sig gravitino-trino-connector-$GRAVITINO_VERSION.tar.gz
-    shasum -a 512 gravitino-trino-connector-$GRAVITINO_VERSION.tar.gz > gravitino-trino-connector-$GRAVITINO_VERSION.tar.gz.sha512
+    echo "Copying and signing Gravitino Trino connector binary distributions"
+    for trino_tar in gravitino-$GRAVITINO_VERSION-bin/distribution/gravitino-trino-connector-*-$GRAVITINO_VERSION.tar.gz; do
+      trino_connector_name=$(basename "$trino_tar" .tar.gz)
+      cp "$trino_tar" .
+      echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \
+        --output ${trino_connector_name}.tar.gz.asc \
+        --detach-sig ${trino_connector_name}.tar.gz
+      shasum -a 512 ${trino_connector_name}.tar.gz > ${trino_connector_name}.tar.gz.sha512
+    done
 
     echo "Copying and signing Gravitino Python client binary distribution"
     cp gravitino-$GRAVITINO_VERSION-bin/clients/client-python/dist/apache_gravitino-$RC_PYGRAVITINO_VERSION.tar.gz .


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add missing Trino connector modules (435-439, 440-445, 446-451, 452-468) to the distribution build, and update the release script to handle multiple connector versions.

Fix: #10139

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.