### PR TITLE
[#5] feat(catalog-glue): PR-01 project scaffolding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1150,6 +1150,7 @@ tasks {
   register("copyCatalogLibAndConfigs", Copy::class) {
     dependsOn(
       ":catalogs:catalog-fileset:copyLibAndConfig",
+      ":catalogs:catalog-glue:copyLibAndConfig",
       ":catalogs:catalog-hive:copyLibAndConfig",
       ":catalogs:catalog-jdbc-doris:copyLibAndConfig",
       ":catalogs:catalog-jdbc-mysql:copyLibAndConfig",

--- a/catalogs/catalog-glue/build.gradle.kts
+++ b/catalogs/catalog-glue/build.gradle.kts
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+description = "catalog-glue"
+
+plugins {
+  `maven-publish`
+  id("java")
+  id("idea")
+}
+
+dependencies {
+  compileOnly(project(":api"))
+  compileOnly(project(":common"))
+  compileOnly(project(":core"))
+
+  compileOnly(libs.lombok)
+
+  implementation(project(":catalogs:catalog-common")) {
+    exclude("*")
+  }
+
+  implementation(libs.aws.glue)
+  implementation(libs.aws.sts)
+  implementation(libs.guava)
+  implementation(libs.slf4j.api)
+
+  annotationProcessor(libs.lombok)
+
+  testImplementation(project(":api"))
+  testImplementation(project(":common"))
+  testImplementation(project(":core"))
+
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.slf4j.api)
+
+  testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+tasks {
+  register("runtimeJars", Copy::class) {
+    from(configurations.runtimeClasspath)
+    into("build/libs")
+  }
+
+  val copyCatalogLibs by registering(Copy::class) {
+    dependsOn("jar", "runtimeJars")
+    from("build/libs") {
+      exclude("guava-*.jar")
+      exclude("log4j-*.jar")
+      exclude("slf4j-*.jar")
+      exclude("error_prone_annotations-*.jar")
+    }
+    into("$rootDir/distribution/package/catalogs/glue/libs")
+  }
+
+  val copyCatalogConfig by registering(Copy::class) {
+    from("src/main/resources")
+    into("$rootDir/distribution/package/catalogs/glue/conf")
+
+    exclude { details ->
+      details.file.isDirectory()
+    }
+
+    fileMode = 0b111101101
+  }
+
+  register("copyLibAndConfig", Copy::class) {
+    dependsOn(copyCatalogConfig, copyCatalogLibs)
+  }
+}
+
+tasks.test {
+  val skipITs = project.hasProperty("skipITs")
+  if (skipITs) {
+    exclude("**/integration/test/**")
+  } else {
+    dependsOn(tasks.jar)
+  }
+}
+
+tasks.getByName("generateMetadataFileForMavenJavaPublication") {
+  dependsOn("runtimeJars")
+}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalog.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalog.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import java.util.Map;
+import org.apache.gravitino.connector.BaseCatalog;
+import org.apache.gravitino.connector.CatalogOperations;
+import org.apache.gravitino.connector.PropertiesMetadata;
+import org.apache.gravitino.connector.capability.Capability;
+
+/**
+ * Implementation of an AWS Glue Data Catalog connector in Apache Gravitino.
+ *
+ * <p>Exposes all Glue table types (Hive, Iceberg, Delta, Parquet) through a single catalog using
+ * {@code provider=glue}.
+ */
+public class GlueCatalog extends BaseCatalog<GlueCatalog> {
+
+  // TODO PR-02: replace stubs with real implementations
+  static final GlueCatalogPropertiesMetadata CATALOG_PROPERTIES_METADATA =
+      new GlueCatalogPropertiesMetadata();
+
+  static final GlueSchemaPropertiesMetadata SCHEMA_PROPERTIES_METADATA =
+      new GlueSchemaPropertiesMetadata();
+
+  static final GlueTablePropertiesMetadata TABLE_PROPERTIES_METADATA =
+      new GlueTablePropertiesMetadata();
+
+  /**
+   * Returns the short name of the Glue catalog.
+   *
+   * @return The short name of the catalog.
+   */
+  @Override
+  public String shortName() {
+    return "glue";
+  }
+
+  /**
+   * Creates a new instance of {@link GlueCatalogOperations} with the provided configuration.
+   *
+   * @param config The configuration map for the Glue catalog operations.
+   * @return A new instance of {@link GlueCatalogOperations}.
+   */
+  @Override
+  protected CatalogOperations newOps(Map<String, String> config) {
+    // TODO PR-04: initialize GlueClient and wire up real operations
+    return new GlueCatalogOperations();
+  }
+
+  @Override
+  public Capability newCapability() {
+    // TODO PR-02: implement GlueCatalogCapability
+    return new GlueCatalogCapability();
+  }
+
+  @Override
+  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+    return CATALOG_PROPERTIES_METADATA;
+  }
+
+  @Override
+  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+    return SCHEMA_PROPERTIES_METADATA;
+  }
+
+  @Override
+  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+    return TABLE_PROPERTIES_METADATA;
+  }
+}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import org.apache.gravitino.connector.capability.Capability;
+
+/**
+ * Capability declarations for the AWS Glue Data Catalog connector.
+ *
+ * <p>TODO PR-02: declare actual capabilities (case sensitivity, NOT NULL support, etc.) based on
+ * Glue's known constraints.
+ */
+public class GlueCatalogCapability implements Capability {}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogOperations.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogOperations.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.gravitino.Catalog;
+import org.apache.gravitino.NameIdentifier;
+import org.apache.gravitino.connector.CatalogInfo;
+import org.apache.gravitino.connector.CatalogOperations;
+import org.apache.gravitino.connector.HasPropertyMetadata;
+
+/**
+ * Operations implementation for the AWS Glue Data Catalog connector.
+ *
+ * <p>This is a scaffold stub. Full implementation will be added in PR-02 through PR-06.
+ *
+ * <p>TODO PR-04: implement SupportsSchemas (Schema CRUD + exception mapping)
+ *
+ * <p>TODO PR-05: implement TableCatalog (Table CRUD + type detection)
+ */
+public class GlueCatalogOperations implements CatalogOperations {
+
+  // TODO PR-04: add GlueClient field and catalogId
+
+  @Override
+  public void initialize(
+      Map<String, String> config, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
+      throws RuntimeException {
+    // TODO PR-04: build GlueClient via GlueClientProvider and store catalogId
+  }
+
+  @Override
+  public void testConnection(
+      NameIdentifier catalogIdent,
+      Catalog.Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties)
+      throws Exception {
+    // TODO PR-04: call GlueClient.getDatabases() to verify connectivity
+  }
+
+  @Override
+  public void close() throws IOException {
+    // TODO PR-04: close GlueClient
+  }
+}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
+import org.apache.gravitino.connector.PropertyEntry;
+
+/**
+ * Properties metadata for the AWS Glue Data Catalog connector.
+ *
+ * <p>TODO PR-02: add required properties (aws-region, aws-glue-catalog-id) and optional properties
+ * (credentials, endpoint override, default-table-format, table-type-filter).
+ */
+public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata {
+
+  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA = ImmutableMap.of();
+
+  @Override
+  protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+    return PROPERTIES_METADATA;
+  }
+}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueSchemaPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueSchemaPropertiesMetadata.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.connector.BasePropertiesMetadata;
+import org.apache.gravitino.connector.PropertyEntry;
+
+/**
+ * Properties metadata for Glue schemas (databases).
+ *
+ * <p>AWS Glue Database has no extra properties beyond name, description, and location, so this
+ * metadata is intentionally empty.
+ */
+public class GlueSchemaPropertiesMetadata extends BasePropertiesMetadata {
+
+  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA = ImmutableMap.of();
+
+  @Override
+  protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+    return PROPERTIES_METADATA;
+  }
+}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.connector.BasePropertiesMetadata;
+import org.apache.gravitino.connector.PropertyEntry;
+
+/**
+ * Properties metadata for Glue tables.
+ *
+ * <p>TODO PR-02: support passthrough of Glue Table.parameters() keys such as {@code table_type} and
+ * {@code metadata_location} for Iceberg, Delta, and other formats.
+ */
+public class GlueTablePropertiesMetadata extends BasePropertiesMetadata {
+
+  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA = ImmutableMap.of();
+
+  @Override
+  protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+    return PROPERTIES_METADATA;
+  }
+}

--- a/catalogs/catalog-glue/src/main/resources/META-INF/services/org.apache.gravitino.CatalogProvider
+++ b/catalogs/catalog-glue/src/main/resources/META-INF/services/org.apache.gravitino.CatalogProvider
@@ -1,0 +1,1 @@
+org.apache.gravitino.catalog.glue.GlueCatalog

--- a/catalogs/catalog-glue/src/main/resources/META-INF/services/org.apache.gravitino.CatalogProvider
+++ b/catalogs/catalog-glue/src/main/resources/META-INF/services/org.apache.gravitino.CatalogProvider
@@ -1,1 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 org.apache.gravitino.catalog.glue.GlueCatalog

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -141,6 +141,7 @@ ql-expression = "4.0.3"
 
 [libraries]
 aspectj-aspectjrt = { group = "org.aspectj", name = "aspectjrt", version.ref = "aspectj" }
+aws-glue = { group = "software.amazon.awssdk", name = "glue", version.ref = "awssdk" }
 aws-iam = { group = "software.amazon.awssdk", name = "iam", version.ref = "awssdk" }
 aws-policy = { group = "software.amazon.awssdk", name = "iam-policy-builder", version.ref = "awssdk" }
 aws-s3 = { group = "software.amazon.awssdk", name = "s3", version.ref = "awssdk" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ val scalaVersion: String = gradle.startParameter.projectProperties["scalaVersion
 
 include("api", "common", "core", "server", "server-common")
 include("catalogs:catalog-common")
+include("catalogs:catalog-glue")
 include("catalogs:catalog-hive")
 include("catalogs:hive-metastore-common")
 include("catalogs:hive-metastore2-libs", "catalogs:hive-metastore3-libs")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Establishes the `catalog-glue` Gradle module — the scaffolding that all subsequent PRs (PR-02 through PR-07) will build on.

**Files added / modified:**

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Add `aws-glue` library alias (reuses existing `awssdk` version ref) |
| `settings.gradle.kts` | `include("catalogs:catalog-glue")` |
| `build.gradle.kts` (root) | Add `:catalogs:catalog-glue:copyLibAndConfig` to `copyCatalogLibAndConfigs` |
| `catalogs/catalog-glue/build.gradle.kts` | Module build file with `aws-glue`, `aws-sts`, and Gravitino `compileOnly` deps; `copyLibAndConfig` task |
| `GlueCatalog.java` | Stub: `extends BaseCatalog<GlueCatalog>`, `shortName()="glue"`, TODO comments for PR-02/04 |
| `GlueCatalogOperations.java` | Stub: `implements CatalogOperations`, empty `initialize`/`testConnection`/`close` |
| `GlueCatalogPropertiesMetadata.java` | Empty catalog properties (PR-02 fills in) |
| `GlueSchemaPropertiesMetadata.java` | Empty schema properties (Glue Database has no extra props) |
| `GlueTablePropertiesMetadata.java` | Empty table properties (PR-02 adds passthrough) |
| `GlueCatalogCapability.java` | Empty capability (PR-02 adds declarations) |
| `META-INF/services/org.apache.gravitino.CatalogProvider` | `org.apache.gravitino.catalog.glue.GlueCatalog` |

## Why are the changes needed?

This is Phase 1, PR-01 of issue #5. Without this scaffolding, PR-02 (GlueClientProvider + config) and PR-03 (domain objects) cannot be developed in parallel.

## Does this PR introduce _any_ user-facing change?

No. All new classes are stubs with TODO comments; no runtime behavior is added yet.

## How was this patch tested?

```bash
./gradlew :catalogs:catalog-glue:build -x test
```

Build succeeds (compileJava + Spotless checks pass).