### PR TITLE
[MINOR] feat(catalog-glue): PR-02 — GlueClientProvider + 配置元数据

### DIFF
--- a/catalogs/catalog-glue/build.gradle.kts
+++ b/catalogs/catalog-glue/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
   implementation(libs.aws.glue)
   implementation(libs.aws.sts)
+  implementation(libs.commons.lang3)
   implementation(libs.guava)
   implementation(libs.slf4j.api)
 

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
@@ -64,9 +64,9 @@ public class GlueCatalogCapability implements Capability {
     switch (scope) {
       case SCHEMA:
       case TABLE:
-      case COLUMN:
         // Glue folds database/table names to lowercase on storage.
         // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html
+        // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html
         return CapabilityResult.unsupported(
             "AWS Glue Data Catalog is case-insensitive for "
                 + scope.name().toLowerCase(java.util.Locale.ROOT)

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
@@ -27,21 +27,34 @@ import org.apache.gravitino.connector.capability.CapabilityResult;
  * <p>AWS Glue constraints that deviate from Gravitino defaults:
  *
  * <ul>
- *   <li>Names (database, table, column) are case-insensitive — Glue normalises them to lowercase.
- *   <li>Column NOT NULL constraints are not enforced by Glue.
- *   <li>Column DEFAULT values are not supported by Glue.
+ *   <li><b>Case-insensitive names</b>: Glue folds database and table names to lowercase on storage.
+ *       See <a
+ *       href="https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html">Database
+ *       API</a> and <a
+ *       href="https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html">Table
+ *       API</a>: <i>"folded to lowercase when it is stored"</i>.
+ *   <li><b>No NOT NULL constraints</b>: The Glue {@code Column} structure has no nullable /
+ *       constraint field. See <a
+ *       href="https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html">Column API</a>.
+ *   <li><b>No DEFAULT values</b>: The Glue {@code Column} structure has no {@code defaultValue}
+ *       field. See <a href="https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html">Column
+ *       API</a>.
  * </ul>
  */
 public class GlueCatalogCapability implements Capability {
 
   @Override
   public CapabilityResult columnNotNull() {
+    // Glue Column structure has no nullable/constraint field — NOT NULL cannot be expressed.
+    // See https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html
     return CapabilityResult.unsupported(
-        "AWS Glue Data Catalog does not enforce NOT NULL constraints on columns.");
+        "AWS Glue Data Catalog does not support NOT NULL constraints on columns.");
   }
 
   @Override
   public CapabilityResult columnDefaultValue() {
+    // Glue Column structure has no defaultValue field — DEFAULT cannot be expressed.
+    // See https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html
     return CapabilityResult.unsupported(
         "AWS Glue Data Catalog does not support DEFAULT values on columns.");
   }
@@ -52,10 +65,11 @@ public class GlueCatalogCapability implements Capability {
       case SCHEMA:
       case TABLE:
       case COLUMN:
-        // Glue normalises database/table/column names to lowercase.
+        // Glue folds database/table names to lowercase on storage.
+        // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html
         return CapabilityResult.unsupported(
             "AWS Glue Data Catalog is case-insensitive for "
-                + scope.name().toLowerCase()
+                + scope.name().toLowerCase(java.util.Locale.ROOT)
                 + " names.");
       default:
         return CapabilityResult.SUPPORTED;

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
@@ -19,11 +19,46 @@
 package org.apache.gravitino.catalog.glue;
 
 import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
 
 /**
  * Capability declarations for the AWS Glue Data Catalog connector.
  *
- * <p>TODO PR-02: declare actual capabilities (case sensitivity, NOT NULL support, etc.) based on
- * Glue's known constraints.
+ * <p>AWS Glue constraints that deviate from Gravitino defaults:
+ *
+ * <ul>
+ *   <li>Names (database, table, column) are case-insensitive — Glue normalises them to lowercase.
+ *   <li>Column NOT NULL constraints are not enforced by Glue.
+ *   <li>Column DEFAULT values are not supported by Glue.
+ * </ul>
  */
-public class GlueCatalogCapability implements Capability {}
+public class GlueCatalogCapability implements Capability {
+
+  @Override
+  public CapabilityResult columnNotNull() {
+    return CapabilityResult.unsupported(
+        "AWS Glue Data Catalog does not enforce NOT NULL constraints on columns.");
+  }
+
+  @Override
+  public CapabilityResult columnDefaultValue() {
+    return CapabilityResult.unsupported(
+        "AWS Glue Data Catalog does not support DEFAULT values on columns.");
+  }
+
+  @Override
+  public CapabilityResult caseSensitiveOnName(Scope scope) {
+    switch (scope) {
+      case SCHEMA:
+      case TABLE:
+      case COLUMN:
+        // Glue normalises database/table/column names to lowercase.
+        return CapabilityResult.unsupported(
+            "AWS Glue Data Catalog is case-insensitive for "
+                + scope.name().toLowerCase()
+                + " names.");
+      default:
+        return CapabilityResult.SUPPORTED;
+    }
+  }
+}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogCapability.java
@@ -18,6 +18,7 @@
  */
 package org.apache.gravitino.catalog.glue;
 
+import java.util.Locale;
 import org.apache.gravitino.connector.capability.Capability;
 import org.apache.gravitino.connector.capability.CapabilityResult;
 
@@ -69,7 +70,7 @@ public class GlueCatalogCapability implements Capability {
         // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html
         return CapabilityResult.unsupported(
             "AWS Glue Data Catalog is case-insensitive for "
-                + scope.name().toLowerCase(java.util.Locale.ROOT)
+                + scope.name().toLowerCase(Locale.ROOT)
                 + " names.");
       default:
         return CapabilityResult.SUPPORTED;

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
@@ -25,8 +25,8 @@ import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_REGION;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_SECRET_ACCESS_KEY;
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT;
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_VALUE;
+import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_TYPE_FILTER;
 import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER;
-import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER_ALL;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 import static org.apache.gravitino.connector.PropertyEntry.stringRequiredPropertyEntry;
 
@@ -87,8 +87,7 @@ public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
               DEFAULT_TABLE_FORMAT,
               stringOptionalPropertyEntry(
                   DEFAULT_TABLE_FORMAT,
-                  "Default format for tables created via createTable(). Accepted: iceberg, hive."
-                      + " Unrecognised values are rejected at createTable() time.",
+                  "Default format for tables created via createTable(). Accepted: iceberg, hive.",
                   false /* immutable */,
                   DEFAULT_TABLE_FORMAT_VALUE,
                   false /* hidden */))
@@ -97,10 +96,9 @@ public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
               stringOptionalPropertyEntry(
                   TABLE_TYPE_FILTER,
                   "Comma-separated table types exposed by listTables() and loadTable()."
-                      + " Accepted: all, hive, iceberg, delta, parquet."
-                      + " Unrecognised values are rejected at listTables() time.",
+                      + " Accepted: all, hive, iceberg.",
                   false /* immutable */,
-                  TABLE_TYPE_FILTER_ALL,
+                  DEFAULT_TABLE_TYPE_FILTER,
                   false /* hidden */))
           .build();
 

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
@@ -18,20 +18,87 @@
  */
 package org.apache.gravitino.catalog.glue;
 
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_ACCESS_KEY_ID;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_CATALOG_ID;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_ENDPOINT;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_REGION;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_SECRET_ACCESS_KEY;
+import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT;
+import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_VALUE;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER_ALL;
+import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
+import static org.apache.gravitino.connector.PropertyEntry.stringRequiredPropertyEntry;
+
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.connector.BaseCatalogPropertiesMetadata;
 import org.apache.gravitino.connector.PropertyEntry;
 
-/**
- * Properties metadata for the AWS Glue Data Catalog connector.
- *
- * <p>TODO PR-02: add required properties (aws-region, aws-glue-catalog-id) and optional properties
- * (credentials, endpoint override, default-table-format, table-type-filter).
- */
+/** Properties metadata for the AWS Glue Data Catalog connector catalog-level configuration. */
 public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata {
 
-  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA = ImmutableMap.of();
+  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA =
+      ImmutableMap.<String, PropertyEntry<?>>builder()
+          .put(
+              AWS_REGION,
+              stringRequiredPropertyEntry(
+                  AWS_REGION,
+                  "AWS region for the Glue Data Catalog (e.g. us-east-1)",
+                  true /* immutable */,
+                  false /* hidden */))
+          .put(
+              AWS_GLUE_CATALOG_ID,
+              stringRequiredPropertyEntry(
+                  AWS_GLUE_CATALOG_ID,
+                  "The 12-digit AWS account ID that owns the Glue catalog",
+                  true /* immutable */,
+                  false /* hidden */))
+          .put(
+              AWS_ACCESS_KEY_ID,
+              stringOptionalPropertyEntry(
+                  AWS_ACCESS_KEY_ID,
+                  "AWS access key ID for static credential authentication."
+                      + " When omitted the default credential chain is used.",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  true /* hidden */))
+          .put(
+              AWS_SECRET_ACCESS_KEY,
+              stringOptionalPropertyEntry(
+                  AWS_SECRET_ACCESS_KEY,
+                  "AWS secret access key paired with aws-access-key-id."
+                      + " When omitted the default credential chain is used.",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  true /* hidden */))
+          .put(
+              AWS_GLUE_ENDPOINT,
+              stringOptionalPropertyEntry(
+                  AWS_GLUE_ENDPOINT,
+                  "Custom Glue endpoint URL for VPC endpoints or LocalStack testing"
+                      + " (e.g. http://localhost:4566)",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */))
+          .put(
+              DEFAULT_TABLE_FORMAT,
+              stringOptionalPropertyEntry(
+                  DEFAULT_TABLE_FORMAT,
+                  "Default format for tables created via createTable(). Accepted: iceberg, hive.",
+                  false /* immutable */,
+                  DEFAULT_TABLE_FORMAT_VALUE,
+                  false /* hidden */))
+          .put(
+              TABLE_TYPE_FILTER,
+              stringOptionalPropertyEntry(
+                  TABLE_TYPE_FILTER,
+                  "Comma-separated table types exposed by listTables() and loadTable()."
+                      + " Accepted: all, hive, iceberg, delta, parquet.",
+                  false /* immutable */,
+                  TABLE_TYPE_FILTER_ALL,
+                  false /* hidden */))
+          .build();
 
   @Override
   protected Map<String, PropertyEntry<?>> specificPropertyEntries() {

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
@@ -49,10 +49,12 @@ public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
                   false /* hidden */))
           .put(
               AWS_GLUE_CATALOG_ID,
-              stringRequiredPropertyEntry(
+              stringOptionalPropertyEntry(
                   AWS_GLUE_CATALOG_ID,
-                  "The 12-digit AWS account ID that owns the Glue catalog",
+                  "The 12-digit AWS account ID that owns the Glue catalog."
+                      + " When omitted, defaults to the caller's AWS account ID.",
                   true /* immutable */,
+                  null /* defaultValue */,
                   false /* hidden */))
           .put(
               AWS_ACCESS_KEY_ID,
@@ -85,7 +87,8 @@ public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
               DEFAULT_TABLE_FORMAT,
               stringOptionalPropertyEntry(
                   DEFAULT_TABLE_FORMAT,
-                  "Default format for tables created via createTable(). Accepted: iceberg, hive.",
+                  "Default format for tables created via createTable(). Accepted: iceberg, hive."
+                      + " Unrecognised values are rejected at createTable() time.",
                   false /* immutable */,
                   DEFAULT_TABLE_FORMAT_VALUE,
                   false /* hidden */))
@@ -94,7 +97,8 @@ public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
               stringOptionalPropertyEntry(
                   TABLE_TYPE_FILTER,
                   "Comma-separated table types exposed by listTables() and loadTable()."
-                      + " Accepted: all, hive, iceberg, delta, parquet.",
+                      + " Accepted: all, hive, iceberg, delta, parquet."
+                      + " Unrecognised values are rejected at listTables() time.",
                   false /* immutable */,
                   TABLE_TYPE_FILTER_ALL,
                   false /* hidden */))

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
@@ -24,9 +24,9 @@ import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_ENDPOINT;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_REGION;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_SECRET_ACCESS_KEY;
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT;
+import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_FILTER;
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_VALUE;
-import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_TYPE_FILTER;
-import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT_FILTER;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 import static org.apache.gravitino.connector.PropertyEntry.stringRequiredPropertyEntry;
 
@@ -92,12 +92,12 @@ public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
                   DEFAULT_TABLE_FORMAT_VALUE,
                   false /* hidden */))
           .put(
-              TABLE_TYPE_FILTER,
+              TABLE_FORMAT_FILTER,
               stringOptionalPropertyEntry(
-                  TABLE_TYPE_FILTER,
-                  "Comma-separated table types exposed by listTables() and loadTable().",
+                  TABLE_FORMAT_FILTER,
+                  "Comma-separated table formats exposed by listTables() and loadTable().",
                   false /* immutable */,
-                  DEFAULT_TABLE_TYPE_FILTER,
+                  DEFAULT_TABLE_FORMAT_FILTER,
                   false /* hidden */))
           .build();
 

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueCatalogPropertiesMetadata.java
@@ -95,8 +95,7 @@ public class GlueCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
               TABLE_TYPE_FILTER,
               stringOptionalPropertyEntry(
                   TABLE_TYPE_FILTER,
-                  "Comma-separated table types exposed by listTables() and loadTable()."
-                      + " Accepted: all, hive, iceberg.",
+                  "Comma-separated table types exposed by listTables() and loadTable().",
                   false /* immutable */,
                   DEFAULT_TABLE_TYPE_FILTER,
                   false /* hidden */))

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
@@ -65,6 +65,13 @@ public final class GlueClientProvider {
 
     // Static credentials take priority over the default credential chain.
     // Both keys must be provided together — a partial pair is always a misconfiguration.
+    // Default credential chain order (when both keys are omitted):
+    //   1. Java system properties (aws.accessKeyId / aws.secretAccessKey)
+    //   2. Environment variables (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+    //   3. Web identity token (EKS / Kubernetes)
+    //   4. ~/.aws/credentials profile file
+    //   5. ECS container task role
+    //   6. EC2 instance profile (IMDSv2)
     String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
     String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
     boolean hasAccessKey = StringUtils.isNotBlank(accessKey);
@@ -87,16 +94,7 @@ public final class GlueClientProvider {
     // Optional custom endpoint override for VPC endpoints or LocalStack testing.
     String endpoint = config.get(GlueConstants.AWS_GLUE_ENDPOINT);
     if (StringUtils.isNotBlank(endpoint)) {
-      try {
-        builder.endpointOverride(URI.create(endpoint));
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Property '%s' contains an invalid URI: '%s'. "
-                    + "Expected a valid URL, e.g. 'http://localhost:4566'. Cause: %s",
-                GlueConstants.AWS_GLUE_ENDPOINT, endpoint, e.getMessage()),
-            e);
-      }
+      builder.endpointOverride(URI.create(endpoint));
     }
 
     return builder.build();

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
@@ -51,7 +51,8 @@ public final class GlueClientProvider {
    *
    * @param config Catalog configuration properties.
    * @return A configured and ready-to-use {@link GlueClient}.
-   * @throws IllegalArgumentException if {@code aws-region} is missing or blank.
+   * @throws IllegalArgumentException if {@code aws-region} is missing or blank, if only one of the
+   *     credential keys is provided, or if {@code aws-glue-endpoint} is not a valid URI.
    */
   public static GlueClient buildClient(Map<String, String> config) {
     String region = config.get(GlueConstants.AWS_REGION);
@@ -63,12 +64,20 @@ public final class GlueClientProvider {
     GlueClientBuilder builder = GlueClient.builder().region(Region.of(region));
 
     // Static credentials take priority over the default credential chain.
+    // Both keys must be provided together — a partial pair is always a misconfiguration.
     String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
     String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
-    if (!Strings.isNullOrEmpty(accessKey)
-        && !accessKey.isBlank()
-        && !Strings.isNullOrEmpty(secretKey)
-        && !secretKey.isBlank()) {
+    boolean hasAccessKey = !Strings.isNullOrEmpty(accessKey) && !accessKey.isBlank();
+    boolean hasSecretKey = !Strings.isNullOrEmpty(secretKey) && !secretKey.isBlank();
+    Preconditions.checkArgument(
+        hasAccessKey == hasSecretKey,
+        "Incomplete static credentials: '%s' requires '%s'. "
+            + "Either provide both keys for static authentication, "
+            + "or omit both to use the default credential chain.",
+        hasAccessKey ? GlueConstants.AWS_ACCESS_KEY_ID : GlueConstants.AWS_SECRET_ACCESS_KEY,
+        hasAccessKey ? GlueConstants.AWS_SECRET_ACCESS_KEY : GlueConstants.AWS_ACCESS_KEY_ID);
+
+    if (hasAccessKey) {
       builder.credentialsProvider(
           StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)));
     } else {
@@ -78,7 +87,16 @@ public final class GlueClientProvider {
     // Optional custom endpoint override for VPC endpoints or LocalStack testing.
     String endpoint = config.get(GlueConstants.AWS_GLUE_ENDPOINT);
     if (!Strings.isNullOrEmpty(endpoint) && !endpoint.isBlank()) {
-      builder.endpointOverride(URI.create(endpoint));
+      try {
+        builder.endpointOverride(URI.create(endpoint));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Property '%s' contains an invalid URI: '%s'. "
+                    + "Expected a valid URL, e.g. 'http://localhost:4566'. Cause: %s",
+                GlueConstants.AWS_GLUE_ENDPOINT, endpoint, e.getMessage()),
+            e);
+      }
     }
 
     return builder.build();

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
@@ -57,7 +57,7 @@ public final class GlueClientProvider {
   public static GlueClient buildClient(Map<String, String> config) {
     String region = config.get(GlueConstants.AWS_REGION);
     Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(region) && !region.isBlank(),
+        !Strings.isNullOrEmpty(region),
         "Property '%s' is required to create a Glue client",
         GlueConstants.AWS_REGION);
 
@@ -67,15 +67,15 @@ public final class GlueClientProvider {
     // Both keys must be provided together — a partial pair is always a misconfiguration.
     String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
     String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
-    boolean hasAccessKey = !Strings.isNullOrEmpty(accessKey) && !accessKey.isBlank();
-    boolean hasSecretKey = !Strings.isNullOrEmpty(secretKey) && !secretKey.isBlank();
+    boolean hasAccessKey = !Strings.isNullOrEmpty(accessKey);
+    boolean hasSecretKey = !Strings.isNullOrEmpty(secretKey);
     Preconditions.checkArgument(
         hasAccessKey == hasSecretKey,
-        "Incomplete static credentials: '%s' requires '%s'. "
+        "Both '%s' and '%s' must be set together. "
             + "Either provide both keys for static authentication, "
             + "or omit both to use the default credential chain.",
-        hasAccessKey ? GlueConstants.AWS_ACCESS_KEY_ID : GlueConstants.AWS_SECRET_ACCESS_KEY,
-        hasAccessKey ? GlueConstants.AWS_SECRET_ACCESS_KEY : GlueConstants.AWS_ACCESS_KEY_ID);
+        GlueConstants.AWS_ACCESS_KEY_ID,
+        GlueConstants.AWS_SECRET_ACCESS_KEY);
 
     if (hasAccessKey) {
       builder.credentialsProvider(
@@ -86,7 +86,7 @@ public final class GlueClientProvider {
 
     // Optional custom endpoint override for VPC endpoints or LocalStack testing.
     String endpoint = config.get(GlueConstants.AWS_GLUE_ENDPOINT);
-    if (!Strings.isNullOrEmpty(endpoint) && !endpoint.isBlank()) {
+    if (!Strings.isNullOrEmpty(endpoint)) {
       try {
         builder.endpointOverride(URI.create(endpoint));
       } catch (IllegalArgumentException e) {

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import java.net.URI;
+import java.util.Map;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.GlueClientBuilder;
+
+/**
+ * Factory for creating AWS {@link GlueClient} instances from Gravitino catalog configuration.
+ *
+ * <p>Authentication priority:
+ *
+ * <ol>
+ *   <li>Static credentials ({@code aws-access-key-id} + {@code aws-secret-access-key})
+ *   <li>Default credential chain (environment variables, instance profile, container credentials)
+ * </ol>
+ *
+ * <p>An optional endpoint override ({@code aws-glue-endpoint}) enables connectivity to VPC
+ * endpoints and LocalStack for integration testing.
+ */
+public final class GlueClientProvider {
+
+  private GlueClientProvider() {}
+
+  /**
+   * Builds a {@link GlueClient} from the given catalog configuration map.
+   *
+   * @param config Catalog configuration properties.
+   * @return A configured and ready-to-use {@link GlueClient}.
+   * @throws IllegalArgumentException if {@code aws-region} is missing or blank.
+   */
+  public static GlueClient buildClient(Map<String, String> config) {
+    String region = config.get(GlueConstants.AWS_REGION);
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(region) && !region.isBlank(),
+        "Property '%s' is required to create a Glue client",
+        GlueConstants.AWS_REGION);
+
+    GlueClientBuilder builder = GlueClient.builder().region(Region.of(region));
+
+    // Static credentials take priority over the default credential chain.
+    String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
+    String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
+    if (!Strings.isNullOrEmpty(accessKey)
+        && !accessKey.isBlank()
+        && !Strings.isNullOrEmpty(secretKey)
+        && !secretKey.isBlank()) {
+      builder.credentialsProvider(
+          StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)));
+    } else {
+      builder.credentialsProvider(DefaultCredentialsProvider.create());
+    }
+
+    // Optional custom endpoint override for VPC endpoints or LocalStack testing.
+    String endpoint = config.get(GlueConstants.AWS_GLUE_ENDPOINT);
+    if (!Strings.isNullOrEmpty(endpoint) && !endpoint.isBlank()) {
+      builder.endpointOverride(URI.create(endpoint));
+    }
+
+    return builder.build();
+  }
+}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueClientProvider.java
@@ -19,9 +19,9 @@
 package org.apache.gravitino.catalog.glue;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import java.net.URI;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -57,7 +57,7 @@ public final class GlueClientProvider {
   public static GlueClient buildClient(Map<String, String> config) {
     String region = config.get(GlueConstants.AWS_REGION);
     Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(region),
+        StringUtils.isNotBlank(region),
         "Property '%s' is required to create a Glue client",
         GlueConstants.AWS_REGION);
 
@@ -67,8 +67,8 @@ public final class GlueClientProvider {
     // Both keys must be provided together — a partial pair is always a misconfiguration.
     String accessKey = config.get(GlueConstants.AWS_ACCESS_KEY_ID);
     String secretKey = config.get(GlueConstants.AWS_SECRET_ACCESS_KEY);
-    boolean hasAccessKey = !Strings.isNullOrEmpty(accessKey);
-    boolean hasSecretKey = !Strings.isNullOrEmpty(secretKey);
+    boolean hasAccessKey = StringUtils.isNotBlank(accessKey);
+    boolean hasSecretKey = StringUtils.isNotBlank(secretKey);
     Preconditions.checkArgument(
         hasAccessKey == hasSecretKey,
         "Both '%s' and '%s' must be set together. "
@@ -86,7 +86,7 @@ public final class GlueClientProvider {
 
     // Optional custom endpoint override for VPC endpoints or LocalStack testing.
     String endpoint = config.get(GlueConstants.AWS_GLUE_ENDPOINT);
-    if (!Strings.isNullOrEmpty(endpoint)) {
+    if (StringUtils.isNotBlank(endpoint)) {
       try {
         builder.endpointOverride(URI.create(endpoint));
       } catch (IllegalArgumentException e) {

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -28,7 +28,10 @@ public final class GlueConstants {
   /** AWS region for the Glue Data Catalog (required). */
   public static final String AWS_REGION = "aws-region";
 
-  /** Glue catalog ID — the 12-digit AWS account ID (required). */
+  /**
+   * Glue catalog ID — the 12-digit AWS account ID (optional). When omitted, defaults to the
+   * caller's AWS account ID.
+   */
   public static final String AWS_GLUE_CATALOG_ID = "aws-glue-catalog-id";
 
   /** AWS access key ID for static credential authentication (optional, sensitive). */
@@ -68,7 +71,9 @@ public final class GlueConstants {
 
   /**
    * Glue table format type parameter key stored in {@code Table.parameters()}. Common values:
-   * {@code ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET}.
+   * {@code ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET} (uppercase, as stored by Glue).
+   * Note: these differ from the Gravitino-side filter values in {@link #TABLE_TYPE_FILTER}, which
+   * use lowercase (e.g. {@code iceberg}, {@code hive}).
    */
   public static final String TABLE_FORMAT_TYPE = "table_format_type";
 

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -63,7 +63,7 @@ public final class GlueConstants {
   public static final String TABLE_TYPE_FILTER = "table-type-filter";
 
   /** Default value for {@link #TABLE_TYPE_FILTER}: expose all table types. */
-  public static final String TABLE_TYPE_FILTER_ALL = "all";
+  public static final String DEFAULT_TABLE_TYPE_FILTER = "all";
 
   // -------------------------------------------------------------------------
   // Glue Table.parameters() keys (passthrough properties)

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -50,7 +50,7 @@ public final class GlueConstants {
   public static final String DEFAULT_TABLE_FORMAT = "default-table-format";
 
   /** Default value for {@link #DEFAULT_TABLE_FORMAT}. */
-  public static final String DEFAULT_TABLE_FORMAT_VALUE = "iceberg";
+  public static final String DEFAULT_TABLE_FORMAT_VALUE = "hive";
 
   /**
    * Comma-separated list of table types exposed by {@code listTables()} and {@code loadTable()}
@@ -67,16 +67,13 @@ public final class GlueConstants {
   // -------------------------------------------------------------------------
 
   /**
-   * Glue table type parameter key. Common values: {@code ICEBERG}, {@code HIVE}, {@code DELTA},
-   * {@code PARQUET}, {@code VIRTUAL_VIEW}.
+   * Glue table format type parameter key stored in {@code Table.parameters()}. Common values:
+   * {@code ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET}, {@code VIRTUAL_VIEW}.
    */
-  public static final String TABLE_TYPE = "table_type";
+  public static final String TABLE_FORMAT_TYPE = "table_format_type";
 
   /** Iceberg table metadata location stored in Glue {@code Table.parameters()}. */
   public static final String METADATA_LOCATION = "metadata_location";
-
-  /** Storage location for the table data. */
-  public static final String LOCATION = "location";
 
   private GlueConstants() {}
 }

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -57,8 +57,7 @@ public final class GlueConstants {
 
   /**
    * Comma-separated list of table types exposed by {@code listTables()} and {@code loadTable()}
-   * (optional). Accepted values: {@code all}, {@code hive}, {@code iceberg}, {@code delta}, {@code
-   * parquet}. Defaults to {@code all}.
+   * (optional). Defaults to {@code all}.
    */
   public static final String TABLE_TYPE_FILTER = "table-type-filter";
 

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -69,12 +69,11 @@ public final class GlueConstants {
   // -------------------------------------------------------------------------
 
   /**
-   * Glue table format type parameter key stored in {@code Table.parameters()}. Common values:
-   * {@code ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET} (uppercase, as stored by Glue).
-   * Note: these differ from the Gravitino-side filter values in {@link #TABLE_FORMAT_FILTER}, which
-   * use lowercase (e.g. {@code iceberg}, {@code hive}).
+   * Glue table format parameter key stored in {@code Table.parameters()}. Common values: {@code
+   * ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET} (uppercase, as stored by Glue). Used
+   * internally to determine the table format when reading Glue tables.
    */
-  public static final String TABLE_FORMAT_TYPE = "table_format_type";
+  public static final String TABLE_FORMAT = "table_format";
 
   /** Iceberg table metadata location stored in Glue {@code Table.parameters()}. */
   public static final String METADATA_LOCATION = "metadata_location";

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -45,11 +45,11 @@ public final class GlueConstants {
 
   /**
    * Default table format used when creating tables via Gravitino's {@code createTable()} API
-   * (optional). Accepted values: {@code iceberg}, {@code hive}. Defaults to {@code iceberg}.
+   * (optional). Accepted values: {@code iceberg}, {@code hive}. Defaults to {@code hive}.
    */
   public static final String DEFAULT_TABLE_FORMAT = "default-table-format";
 
-  /** Default value for {@link #DEFAULT_TABLE_FORMAT}. */
+  /** Default value for {@link #DEFAULT_TABLE_FORMAT}: {@code "hive"}. */
   public static final String DEFAULT_TABLE_FORMAT_VALUE = "hive";
 
   /**

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -56,13 +56,13 @@ public final class GlueConstants {
   public static final String DEFAULT_TABLE_FORMAT_VALUE = "hive";
 
   /**
-   * Comma-separated list of table types exposed by {@code listTables()} and {@code loadTable()}
+   * Comma-separated list of table formats exposed by {@code listTables()} and {@code loadTable()}
    * (optional). Defaults to {@code all}.
    */
-  public static final String TABLE_TYPE_FILTER = "table-type-filter";
+  public static final String TABLE_FORMAT_FILTER = "table-format-filter";
 
-  /** Default value for {@link #TABLE_TYPE_FILTER}: expose all table types. */
-  public static final String DEFAULT_TABLE_TYPE_FILTER = "all";
+  /** Default value for {@link #TABLE_FORMAT_FILTER}: expose all table formats. */
+  public static final String DEFAULT_TABLE_FORMAT_FILTER = "all";
 
   // -------------------------------------------------------------------------
   // Glue Table.parameters() keys (passthrough properties)
@@ -71,7 +71,7 @@ public final class GlueConstants {
   /**
    * Glue table format type parameter key stored in {@code Table.parameters()}. Common values:
    * {@code ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET} (uppercase, as stored by Glue).
-   * Note: these differ from the Gravitino-side filter values in {@link #TABLE_TYPE_FILTER}, which
+   * Note: these differ from the Gravitino-side filter values in {@link #TABLE_FORMAT_FILTER}, which
    * use lowercase (e.g. {@code iceberg}, {@code hive}).
    */
   public static final String TABLE_FORMAT_TYPE = "table_format_type";

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -73,7 +73,7 @@ public final class GlueConstants {
    * ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET} (uppercase, as stored by Glue). Used
    * internally to determine the table format when reading Glue tables.
    */
-  public static final String TABLE_FORMAT = "table_format";
+  public static final String TABLE_FORMAT = "table-format";
 
   /** Iceberg table metadata location stored in Glue {@code Table.parameters()}. */
   public static final String METADATA_LOCATION = "metadata_location";

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -68,7 +68,7 @@ public final class GlueConstants {
 
   /**
    * Glue table format type parameter key stored in {@code Table.parameters()}. Common values:
-   * {@code ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET}, {@code VIRTUAL_VIEW}.
+   * {@code ICEBERG}, {@code HIVE}, {@code DELTA}, {@code PARQUET}.
    */
   public static final String TABLE_FORMAT_TYPE = "table_format_type";
 

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueConstants.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+/** Constant keys for the AWS Glue Data Catalog connector configuration and table properties. */
+public final class GlueConstants {
+
+  // -------------------------------------------------------------------------
+  // Catalog-level connection properties
+  // -------------------------------------------------------------------------
+
+  /** AWS region for the Glue Data Catalog (required). */
+  public static final String AWS_REGION = "aws-region";
+
+  /** Glue catalog ID — the 12-digit AWS account ID (required). */
+  public static final String AWS_GLUE_CATALOG_ID = "aws-glue-catalog-id";
+
+  /** AWS access key ID for static credential authentication (optional, sensitive). */
+  public static final String AWS_ACCESS_KEY_ID = "aws-access-key-id";
+
+  /** AWS secret access key for static credential authentication (optional, sensitive). */
+  public static final String AWS_SECRET_ACCESS_KEY = "aws-secret-access-key";
+
+  /**
+   * Custom Glue endpoint URL (optional). Used for VPC endpoints or LocalStack testing. Example:
+   * {@code http://localhost:4566}
+   */
+  public static final String AWS_GLUE_ENDPOINT = "aws-glue-endpoint";
+
+  /**
+   * Default table format used when creating tables via Gravitino's {@code createTable()} API
+   * (optional). Accepted values: {@code iceberg}, {@code hive}. Defaults to {@code iceberg}.
+   */
+  public static final String DEFAULT_TABLE_FORMAT = "default-table-format";
+
+  /** Default value for {@link #DEFAULT_TABLE_FORMAT}. */
+  public static final String DEFAULT_TABLE_FORMAT_VALUE = "iceberg";
+
+  /**
+   * Comma-separated list of table types exposed by {@code listTables()} and {@code loadTable()}
+   * (optional). Accepted values: {@code all}, {@code hive}, {@code iceberg}, {@code delta}, {@code
+   * parquet}. Defaults to {@code all}.
+   */
+  public static final String TABLE_TYPE_FILTER = "table-type-filter";
+
+  /** Default value for {@link #TABLE_TYPE_FILTER}: expose all table types. */
+  public static final String TABLE_TYPE_FILTER_ALL = "all";
+
+  // -------------------------------------------------------------------------
+  // Glue Table.parameters() keys (passthrough properties)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Glue table type parameter key. Common values: {@code ICEBERG}, {@code HIVE}, {@code DELTA},
+   * {@code PARQUET}, {@code VIRTUAL_VIEW}.
+   */
+  public static final String TABLE_TYPE = "table_type";
+
+  /** Iceberg table metadata location stored in Glue {@code Table.parameters()}. */
+  public static final String METADATA_LOCATION = "metadata_location";
+
+  /** Storage location for the table data. */
+  public static final String LOCATION = "location";
+
+  private GlueConstants() {}
+}

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
@@ -18,9 +18,8 @@
  */
 package org.apache.gravitino.catalog.glue;
 
-import static org.apache.gravitino.catalog.glue.GlueConstants.LOCATION;
 import static org.apache.gravitino.catalog.glue.GlueConstants.METADATA_LOCATION;
-import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT_TYPE;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 
 import com.google.common.collect.ImmutableMap;
@@ -35,16 +34,19 @@ import org.apache.gravitino.connector.PropertyEntry;
  * are optional and mutable, reflecting that Glue stores them as free-form key-value pairs. Unknown
  * parameters from {@code Table.parameters()} are passed through transparently by the catalog
  * operations layer and are not validated here.
+ *
+ * <p>Note: storage location ({@code StorageDescriptor.location}) varies by table format and is
+ * handled per-format in the Table CRUD layer (PR-05), not declared here.
  */
 public class GlueTablePropertiesMetadata extends BasePropertiesMetadata {
 
   private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA =
       ImmutableMap.<String, PropertyEntry<?>>builder()
           .put(
-              TABLE_TYPE,
+              TABLE_FORMAT_TYPE,
               stringOptionalPropertyEntry(
-                  TABLE_TYPE,
-                  "Glue table type stored in Table.parameters(). Common values:"
+                  TABLE_FORMAT_TYPE,
+                  "Glue table format type stored in Table.parameters(). Common values:"
                       + " ICEBERG, HIVE, DELTA, PARQUET.",
                   false /* immutable */,
                   null /* defaultValue */,
@@ -54,14 +56,6 @@ public class GlueTablePropertiesMetadata extends BasePropertiesMetadata {
               stringOptionalPropertyEntry(
                   METADATA_LOCATION,
                   "Iceberg metadata file location stored in Table.parameters().",
-                  false /* immutable */,
-                  null /* defaultValue */,
-                  false /* hidden */))
-          .put(
-              LOCATION,
-              stringOptionalPropertyEntry(
-                  LOCATION,
-                  "Storage location for the table data.",
                   false /* immutable */,
                   null /* defaultValue */,
                   false /* hidden */))

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
@@ -19,7 +19,6 @@
 package org.apache.gravitino.catalog.glue;
 
 import static org.apache.gravitino.catalog.glue.GlueConstants.METADATA_LOCATION;
-import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT_TYPE;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 
 import com.google.common.collect.ImmutableMap;
@@ -42,15 +41,6 @@ public class GlueTablePropertiesMetadata extends BasePropertiesMetadata {
 
   private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA =
       ImmutableMap.<String, PropertyEntry<?>>builder()
-          .put(
-              TABLE_FORMAT_TYPE,
-              stringOptionalPropertyEntry(
-                  TABLE_FORMAT_TYPE,
-                  "Glue table format type stored in Table.parameters(). Common values:"
-                      + " iceberg, hive.",
-                  false /* immutable */,
-                  null /* defaultValue */,
-                  false /* hidden */))
           .put(
               METADATA_LOCATION,
               stringOptionalPropertyEntry(

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
@@ -36,7 +36,7 @@ import org.apache.gravitino.connector.PropertyEntry;
  * operations layer and are not validated here.
  *
  * <p>Note: storage location ({@code StorageDescriptor.location}) varies by table format and is
- * handled per-format in the Table CRUD layer (PR-05), not declared here.
+ * handled per-format in the Table CRUD layer, not declared here.
  */
 public class GlueTablePropertiesMetadata extends BasePropertiesMetadata {
 

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.glue;
 
 import static org.apache.gravitino.catalog.glue.GlueConstants.METADATA_LOCATION;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT;
 import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
 
 import com.google.common.collect.ImmutableMap;
@@ -41,6 +42,14 @@ public class GlueTablePropertiesMetadata extends BasePropertiesMetadata {
 
   private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA =
       ImmutableMap.<String, PropertyEntry<?>>builder()
+          .put(
+              TABLE_FORMAT,
+              stringOptionalPropertyEntry(
+                  TABLE_FORMAT,
+                  "Table format stored in Table.parameters(). Common values: iceberg, hive.",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */))
           .put(
               METADATA_LOCATION,
               stringOptionalPropertyEntry(

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
@@ -18,6 +18,11 @@
  */
 package org.apache.gravitino.catalog.glue;
 
+import static org.apache.gravitino.catalog.glue.GlueConstants.LOCATION;
+import static org.apache.gravitino.catalog.glue.GlueConstants.METADATA_LOCATION;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE;
+import static org.apache.gravitino.connector.PropertyEntry.stringOptionalPropertyEntry;
+
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.gravitino.connector.BasePropertiesMetadata;
@@ -26,12 +31,41 @@ import org.apache.gravitino.connector.PropertyEntry;
 /**
  * Properties metadata for Glue tables.
  *
- * <p>TODO PR-02: support passthrough of Glue Table.parameters() keys such as {@code table_type} and
- * {@code metadata_location} for Iceberg, Delta, and other formats.
+ * <p>Defines well-known Glue {@code Table.parameters()} keys that Gravitino exposes. All entries
+ * are optional and mutable, reflecting that Glue stores them as free-form key-value pairs. Unknown
+ * parameters from {@code Table.parameters()} are passed through transparently by the catalog
+ * operations layer and are not validated here.
  */
 public class GlueTablePropertiesMetadata extends BasePropertiesMetadata {
 
-  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA = ImmutableMap.of();
+  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA =
+      ImmutableMap.<String, PropertyEntry<?>>builder()
+          .put(
+              TABLE_TYPE,
+              stringOptionalPropertyEntry(
+                  TABLE_TYPE,
+                  "Glue table type stored in Table.parameters(). Common values:"
+                      + " ICEBERG, HIVE, DELTA, PARQUET.",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */))
+          .put(
+              METADATA_LOCATION,
+              stringOptionalPropertyEntry(
+                  METADATA_LOCATION,
+                  "Iceberg metadata file location stored in Table.parameters().",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */))
+          .put(
+              LOCATION,
+              stringOptionalPropertyEntry(
+                  LOCATION,
+                  "Storage location for the table data.",
+                  false /* immutable */,
+                  null /* defaultValue */,
+                  false /* hidden */))
+          .build();
 
   @Override
   protected Map<String, PropertyEntry<?>> specificPropertyEntries() {

--- a/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/main/java/org/apache/gravitino/catalog/glue/GlueTablePropertiesMetadata.java
@@ -47,7 +47,7 @@ public class GlueTablePropertiesMetadata extends BasePropertiesMetadata {
               stringOptionalPropertyEntry(
                   TABLE_FORMAT_TYPE,
                   "Glue table format type stored in Table.parameters(). Common values:"
-                      + " ICEBERG, HIVE, DELTA, PARQUET.",
+                      + " iceberg, hive.",
                   false /* immutable */,
                   null /* defaultValue */,
                   false /* hidden */))

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogCapability.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogCapability.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.gravitino.connector.capability.Capability;
+import org.apache.gravitino.connector.capability.CapabilityResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestGlueCatalogCapability {
+
+  private GlueCatalogCapability capability;
+
+  @BeforeEach
+  void setUp() {
+    capability = new GlueCatalogCapability();
+  }
+
+  @Test
+  void testColumnNotNullIsUnsupported() {
+    CapabilityResult result = capability.columnNotNull();
+    assertFalse(result.supported(), "Glue does not enforce NOT NULL constraints");
+    assertNotNull(result.unsupportedMessage());
+    assertFalse(result.unsupportedMessage().isEmpty());
+  }
+
+  @Test
+  void testColumnDefaultValueIsUnsupported() {
+    CapabilityResult result = capability.columnDefaultValue();
+    assertFalse(result.supported(), "Glue does not support DEFAULT values on columns");
+    assertNotNull(result.unsupportedMessage());
+    assertFalse(result.unsupportedMessage().isEmpty());
+  }
+
+  @Test
+  void testCaseSensitiveOnSchemaIsUnsupported() {
+    CapabilityResult result = capability.caseSensitiveOnName(Capability.Scope.SCHEMA);
+    assertFalse(result.supported(), "Glue folds schema names to lowercase");
+    assertNotNull(result.unsupportedMessage());
+  }
+
+  @Test
+  void testCaseSensitiveOnTableIsUnsupported() {
+    CapabilityResult result = capability.caseSensitiveOnName(Capability.Scope.TABLE);
+    assertFalse(result.supported(), "Glue folds table names to lowercase");
+    assertNotNull(result.unsupportedMessage());
+  }
+
+  @Test
+  void testCaseSensitiveOnColumnIsSupported() {
+    // Column name case folding is not documented in Glue Column API — treated as supported.
+    CapabilityResult result = capability.caseSensitiveOnName(Capability.Scope.COLUMN);
+    assertTrue(result.supported());
+  }
+}

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
@@ -49,8 +49,8 @@ class TestGlueCatalogPropertiesMetadata {
   }
 
   @Test
-  void testAwsGlueCatalogIdIsRequired() {
-    assertTrue(metadata.isRequiredProperty(AWS_GLUE_CATALOG_ID));
+  void testAwsGlueCatalogIdIsOptional() {
+    assertFalse(metadata.isRequiredProperty(AWS_GLUE_CATALOG_ID));
   }
 
   @Test

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_ACCESS_KEY_ID;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_CATALOG_ID;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_ENDPOINT;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_REGION;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_SECRET_ACCESS_KEY;
+import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT;
+import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_VALUE;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER_ALL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestGlueCatalogPropertiesMetadata {
+
+  private GlueCatalogPropertiesMetadata metadata;
+
+  @BeforeEach
+  void setUp() {
+    metadata = new GlueCatalogPropertiesMetadata();
+  }
+
+  @Test
+  void testAwsRegionIsRequired() {
+    assertTrue(metadata.isRequiredProperty(AWS_REGION));
+  }
+
+  @Test
+  void testAwsGlueCatalogIdIsRequired() {
+    assertTrue(metadata.isRequiredProperty(AWS_GLUE_CATALOG_ID));
+  }
+
+  @Test
+  void testAwsRegionIsImmutable() {
+    assertTrue(metadata.isImmutableProperty(AWS_REGION));
+  }
+
+  @Test
+  void testAwsGlueCatalogIdIsImmutable() {
+    assertTrue(metadata.isImmutableProperty(AWS_GLUE_CATALOG_ID));
+  }
+
+  @Test
+  void testCredentialsAreHidden() {
+    assertTrue(metadata.isHiddenProperty(AWS_ACCESS_KEY_ID));
+    assertTrue(metadata.isHiddenProperty(AWS_SECRET_ACCESS_KEY));
+  }
+
+  @Test
+  void testCredentialsAreOptional() {
+    assertFalse(metadata.isRequiredProperty(AWS_ACCESS_KEY_ID));
+    assertFalse(metadata.isRequiredProperty(AWS_SECRET_ACCESS_KEY));
+  }
+
+  @Test
+  void testEndpointIsOptionalAndNotHidden() {
+    assertFalse(metadata.isRequiredProperty(AWS_GLUE_ENDPOINT));
+    assertFalse(metadata.isHiddenProperty(AWS_GLUE_ENDPOINT));
+  }
+
+  @Test
+  void testDefaultTableFormatDefaultValue() {
+    assertEquals(
+        DEFAULT_TABLE_FORMAT_VALUE,
+        metadata.getDefaultValue(DEFAULT_TABLE_FORMAT),
+        "Default table format should be 'hive'");
+  }
+
+  @Test
+  void testTableTypeFilterDefaultValue() {
+    assertEquals(
+        TABLE_TYPE_FILTER_ALL,
+        metadata.getDefaultValue(TABLE_TYPE_FILTER),
+        "Default table type filter should be 'all'");
+  }
+}

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
@@ -24,9 +24,9 @@ import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_ENDPOINT;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_REGION;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_SECRET_ACCESS_KEY;
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT;
+import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_FILTER;
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_VALUE;
-import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_TYPE_FILTER;
-import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT_FILTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -90,10 +90,10 @@ class TestGlueCatalogPropertiesMetadata {
   }
 
   @Test
-  void testTableTypeFilterDefaultValue() {
+  void testTableFormatFilterDefaultValue() {
     assertEquals(
-        DEFAULT_TABLE_TYPE_FILTER,
-        metadata.getDefaultValue(TABLE_TYPE_FILTER),
-        "Default table type filter should be 'all'");
+        DEFAULT_TABLE_FORMAT_FILTER,
+        metadata.getDefaultValue(TABLE_FORMAT_FILTER),
+        "Default table format filter should be 'all'");
   }
 }

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueCatalogPropertiesMetadata.java
@@ -25,8 +25,8 @@ import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_REGION;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_SECRET_ACCESS_KEY;
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT;
 import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_FORMAT_VALUE;
+import static org.apache.gravitino.catalog.glue.GlueConstants.DEFAULT_TABLE_TYPE_FILTER;
 import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER;
-import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_TYPE_FILTER_ALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -92,7 +92,7 @@ class TestGlueCatalogPropertiesMetadata {
   @Test
   void testTableTypeFilterDefaultValue() {
     assertEquals(
-        TABLE_TYPE_FILTER_ALL,
+        DEFAULT_TABLE_TYPE_FILTER,
         metadata.getDefaultValue(TABLE_TYPE_FILTER),
         "Default table type filter should be 'all'");
   }

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueClientProvider.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueClientProvider.java
@@ -116,8 +116,6 @@ class TestGlueClientProvider {
     config.put(AWS_REGION, "us-east-1");
     config.put(AWS_GLUE_ENDPOINT, "not a valid uri ://");
 
-    IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> GlueClientProvider.buildClient(config));
-    assertTrue(ex.getMessage().contains(AWS_GLUE_ENDPOINT));
+    assertThrows(IllegalArgumentException.class, () -> GlueClientProvider.buildClient(config));
   }
 }

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueClientProvider.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueClientProvider.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_ACCESS_KEY_ID;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_GLUE_ENDPOINT;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_REGION;
+import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_SECRET_ACCESS_KEY;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.glue.GlueClient;
+
+class TestGlueClientProvider {
+
+  @Test
+  void testBuildClientWithStaticCredentials() {
+    Map<String, String> config = new HashMap<>();
+    config.put(AWS_REGION, "us-east-1");
+    config.put(AWS_ACCESS_KEY_ID, "AKIAIOSFODNN7EXAMPLE");
+    config.put(AWS_SECRET_ACCESS_KEY, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+    GlueClient client = GlueClientProvider.buildClient(config);
+    assertNotNull(client);
+    client.close();
+  }
+
+  @Test
+  void testBuildClientWithDefaultCredentialChain() {
+    // Without explicit credentials the default chain is used.
+    Map<String, String> config = new HashMap<>();
+    config.put(AWS_REGION, "eu-west-1");
+
+    GlueClient client = GlueClientProvider.buildClient(config);
+    assertNotNull(client);
+    client.close();
+  }
+
+  @Test
+  void testBuildClientWithEndpointOverride() {
+    Map<String, String> config = new HashMap<>();
+    config.put(AWS_REGION, "us-east-1");
+    config.put(AWS_ACCESS_KEY_ID, "test");
+    config.put(AWS_SECRET_ACCESS_KEY, "test");
+    config.put(AWS_GLUE_ENDPOINT, "http://localhost:4566");
+
+    GlueClient client = GlueClientProvider.buildClient(config);
+    assertNotNull(client);
+    client.close();
+  }
+
+  @Test
+  void testBuildClientMissingRegionThrows() {
+    Map<String, String> config = new HashMap<>();
+    // No AWS_REGION set.
+
+    assertThrows(IllegalArgumentException.class, () -> GlueClientProvider.buildClient(config));
+  }
+
+  @Test
+  void testBuildClientBlankRegionThrows() {
+    Map<String, String> config = new HashMap<>();
+    config.put(AWS_REGION, "   ");
+
+    assertThrows(IllegalArgumentException.class, () -> GlueClientProvider.buildClient(config));
+  }
+
+  @Test
+  void testBuildClientOnlyAccessKeyFallsBackToDefaultChain() {
+    // Only one of the key pair provided → both must be present to use static creds.
+    // Falls back to default chain, which just builds without error.
+    Map<String, String> config = new HashMap<>();
+    config.put(AWS_REGION, "ap-southeast-1");
+    config.put(AWS_ACCESS_KEY_ID, "AKIAIOSFODNN7EXAMPLE");
+    // No AWS_SECRET_ACCESS_KEY → default chain is used instead.
+
+    GlueClient client = GlueClientProvider.buildClient(config);
+    assertNotNull(client);
+    client.close();
+  }
+}

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueClientProvider.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueClientProvider.java
@@ -37,8 +37,8 @@ class TestGlueClientProvider {
   void testBuildClientWithStaticCredentials() {
     Map<String, String> config = new HashMap<>();
     config.put(AWS_REGION, "us-east-1");
-    config.put(AWS_ACCESS_KEY_ID, "AKIAIOSFODNN7EXAMPLE");
-    config.put(AWS_SECRET_ACCESS_KEY, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+    config.put(AWS_ACCESS_KEY_ID, "test-access-key");
+    config.put(AWS_SECRET_ACCESS_KEY, "test-secret-key");
 
     try (GlueClient client = GlueClientProvider.buildClient(config)) {
       assertNotNull(client);
@@ -102,7 +102,7 @@ class TestGlueClientProvider {
     // Providing only the secret without the access key is also a misconfiguration.
     Map<String, String> config = new HashMap<>();
     config.put(AWS_REGION, "ap-southeast-1");
-    config.put(AWS_SECRET_ACCESS_KEY, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+    config.put(AWS_SECRET_ACCESS_KEY, "test-secret-key");
     // No AWS_ACCESS_KEY_ID.
 
     IllegalArgumentException ex =

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueClientProvider.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueClientProvider.java
@@ -24,6 +24,7 @@ import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_REGION;
 import static org.apache.gravitino.catalog.glue.GlueConstants.AWS_SECRET_ACCESS_KEY;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,9 +40,9 @@ class TestGlueClientProvider {
     config.put(AWS_ACCESS_KEY_ID, "AKIAIOSFODNN7EXAMPLE");
     config.put(AWS_SECRET_ACCESS_KEY, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
 
-    GlueClient client = GlueClientProvider.buildClient(config);
-    assertNotNull(client);
-    client.close();
+    try (GlueClient client = GlueClientProvider.buildClient(config)) {
+      assertNotNull(client);
+    }
   }
 
   @Test
@@ -50,9 +51,9 @@ class TestGlueClientProvider {
     Map<String, String> config = new HashMap<>();
     config.put(AWS_REGION, "eu-west-1");
 
-    GlueClient client = GlueClientProvider.buildClient(config);
-    assertNotNull(client);
-    client.close();
+    try (GlueClient client = GlueClientProvider.buildClient(config)) {
+      assertNotNull(client);
+    }
   }
 
   @Test
@@ -63,15 +64,14 @@ class TestGlueClientProvider {
     config.put(AWS_SECRET_ACCESS_KEY, "test");
     config.put(AWS_GLUE_ENDPOINT, "http://localhost:4566");
 
-    GlueClient client = GlueClientProvider.buildClient(config);
-    assertNotNull(client);
-    client.close();
+    try (GlueClient client = GlueClientProvider.buildClient(config)) {
+      assertNotNull(client);
+    }
   }
 
   @Test
   void testBuildClientMissingRegionThrows() {
     Map<String, String> config = new HashMap<>();
-    // No AWS_REGION set.
 
     assertThrows(IllegalArgumentException.class, () -> GlueClientProvider.buildClient(config));
   }
@@ -85,16 +85,39 @@ class TestGlueClientProvider {
   }
 
   @Test
-  void testBuildClientOnlyAccessKeyFallsBackToDefaultChain() {
-    // Only one of the key pair provided → both must be present to use static creds.
-    // Falls back to default chain, which just builds without error.
+  void testBuildClientOnlyAccessKeyThrows() {
+    // Providing only one of the credential pair is always a misconfiguration — must fail fast.
     Map<String, String> config = new HashMap<>();
     config.put(AWS_REGION, "ap-southeast-1");
     config.put(AWS_ACCESS_KEY_ID, "AKIAIOSFODNN7EXAMPLE");
-    // No AWS_SECRET_ACCESS_KEY → default chain is used instead.
+    // No AWS_SECRET_ACCESS_KEY.
 
-    GlueClient client = GlueClientProvider.buildClient(config);
-    assertNotNull(client);
-    client.close();
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> GlueClientProvider.buildClient(config));
+    assertTrue(ex.getMessage().contains(AWS_SECRET_ACCESS_KEY));
+  }
+
+  @Test
+  void testBuildClientOnlySecretKeyThrows() {
+    // Providing only the secret without the access key is also a misconfiguration.
+    Map<String, String> config = new HashMap<>();
+    config.put(AWS_REGION, "ap-southeast-1");
+    config.put(AWS_SECRET_ACCESS_KEY, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+    // No AWS_ACCESS_KEY_ID.
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> GlueClientProvider.buildClient(config));
+    assertTrue(ex.getMessage().contains(AWS_ACCESS_KEY_ID));
+  }
+
+  @Test
+  void testBuildClientInvalidEndpointThrows() {
+    Map<String, String> config = new HashMap<>();
+    config.put(AWS_REGION, "us-east-1");
+    config.put(AWS_GLUE_ENDPOINT, "not a valid uri ://");
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> GlueClientProvider.buildClient(config));
+    assertTrue(ex.getMessage().contains(AWS_GLUE_ENDPOINT));
   }
 }

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTablePropertiesMetadata.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.catalog.glue;
 
 import static org.apache.gravitino.catalog.glue.GlueConstants.METADATA_LOCATION;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,16 @@ class TestGlueTablePropertiesMetadata {
   @BeforeEach
   void setUp() {
     metadata = new GlueTablePropertiesMetadata();
+  }
+
+  @Test
+  void testTableFormatIsOptional() {
+    assertFalse(metadata.isRequiredProperty(TABLE_FORMAT));
+  }
+
+  @Test
+  void testTableFormatIsNotHidden() {
+    assertFalse(metadata.isHiddenProperty(TABLE_FORMAT));
   }
 
   @Test

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTablePropertiesMetadata.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.catalog.glue;
+
+import static org.apache.gravitino.catalog.glue.GlueConstants.METADATA_LOCATION;
+import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT_TYPE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestGlueTablePropertiesMetadata {
+
+  private GlueTablePropertiesMetadata metadata;
+
+  @BeforeEach
+  void setUp() {
+    metadata = new GlueTablePropertiesMetadata();
+  }
+
+  @Test
+  void testTableFormatTypeIsOptional() {
+    assertFalse(metadata.isRequiredProperty(TABLE_FORMAT_TYPE));
+  }
+
+  @Test
+  void testTableFormatTypeIsNotHidden() {
+    assertFalse(metadata.isHiddenProperty(TABLE_FORMAT_TYPE));
+  }
+
+  @Test
+  void testMetadataLocationIsOptional() {
+    assertFalse(metadata.isRequiredProperty(METADATA_LOCATION));
+  }
+
+  @Test
+  void testMetadataLocationIsNotHidden() {
+    assertFalse(metadata.isHiddenProperty(METADATA_LOCATION));
+  }
+}

--- a/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTablePropertiesMetadata.java
+++ b/catalogs/catalog-glue/src/test/java/org/apache/gravitino/catalog/glue/TestGlueTablePropertiesMetadata.java
@@ -19,7 +19,6 @@
 package org.apache.gravitino.catalog.glue;
 
 import static org.apache.gravitino.catalog.glue.GlueConstants.METADATA_LOCATION;
-import static org.apache.gravitino.catalog.glue.GlueConstants.TABLE_FORMAT_TYPE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,16 +31,6 @@ class TestGlueTablePropertiesMetadata {
   @BeforeEach
   void setUp() {
     metadata = new GlueTablePropertiesMetadata();
-  }
-
-  @Test
-  void testTableFormatTypeIsOptional() {
-    assertFalse(metadata.isRequiredProperty(TABLE_FORMAT_TYPE));
-  }
-
-  @Test
-  void testTableFormatTypeIsNotHidden() {
-    assertFalse(metadata.isHiddenProperty(TABLE_FORMAT_TYPE));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implements PR-02 from the Phase 1 plan (see diqiu50/gravitino#5):

- **GlueConstants**: all catalog and table property key constants
- **GlueClientProvider**: builds `GlueClient` with static credentials or
  `DefaultCredentialsProvider`, region, and optional endpoint override (VPC / LocalStack)
- **GlueCatalogPropertiesMetadata**: required `aws-region` + `aws-glue-catalog-id`;
  optional credentials (hidden), `aws-glue-endpoint`, `default-table-format`, `table-type-filter`
- **GlueCatalogCapability**: declares Glue constraints — case-insensitive names, no NOT NULL, no DEFAULT
- **GlueTablePropertiesMetadata**: `table_type`, `metadata_location`, `location` passthrough entries
- **TestGlueClientProvider**: unit tests covering static creds, default chain, endpoint override, missing region

## Why are the changes needed?

AWS connection layer and property definitions are prerequisites for all subsequent PRs
(Schema CRUD in PR-04, Table CRUD in PR-05).

## Does this PR introduce any user-facing change?

No.

## How was this patch tested?

`./gradlew :catalogs:catalog-glue:test -PskipITs`